### PR TITLE
Destroyable Mail, Garbage, and Contraband

### DIFF
--- a/json/level_testJ.json
+++ b/json/level_testJ.json
@@ -1,0 +1,25 @@
+{
+  "meta": {
+    "format": "PP-level",
+    "format-version": 1,
+    "name-internal": "level1",
+    "name-external": "Level 1"
+  },
+  "nodes": [
+    {"type": "NodeConveyorNormal", "x": 9, "y": 2, "dir": "up"},
+    {"type": "NodeConveyorNormal", "x": 9, "y": 3, "dir": "down"},
+    {"type": "NodeConveyorNormal", "x": 3, "y": 4, "dir": "down"},
+    {"type": "NodeGroupRect", "subtype": "NodeConveyorNormal", "x1": 0, "y1": 2, "x2": 8, "y2": 2, "dir": "right"},
+    {"type": "NodeGroupRect", "subtype": "NodeConveyorNormal", "x1": 4, "y1": 4, "x2": 9, "y2": 4, "dir": "right"},
+    {"type": "NodeGroupRect", "subtype": "NodeConveyorNormal", "x1": 10, "y1": 4, "x2": 10, "y2": 8, "dir": "down"},
+    {"type": "NodeBin", "x": 3, "y": 3}
+  ],
+  "mail": [
+    {"type": "MailContraband", "x": 0, "y": 2 }
+  ],
+  "notes": [
+    {"author": "Mr. Foo", "date": "2015-01-17T19:38-05", "note": "We should add xyz."},
+    {"author": "Mr. Bar", "date": "2015-01-18T13:30-05", "note": "We should NOT add xyz."}
+  ]
+}
+

--- a/obj/PackagePanicConfig.old
+++ b/obj/PackagePanicConfig.old
@@ -16,7 +16,7 @@
     </define>
     <define append="true">
       <name>CONFIG::timeStamp</name>
-      <value>'2/16/2015'</value>
+      <value>'2/25/2015'</value>
     </define>
     <define append="true">
       <name>CONFIG::air</name>
@@ -32,19 +32,19 @@
     </define>
     <verbose-stacktraces>true</verbose-stacktraces>
     <source-path append="true">
-      <path-element>C:\Users\Someone\Documents\GitHub\package-panic\src</path-element>
+      <path-element>D:\Documents\GitHub\package-panic\src</path-element>
       <path-element>C:\Program Files (x86)\FlashDevelop\Library\AS3\classes</path-element>
     </source-path>
     <library-path append="true">
-      <path-element>C:\Users\Someone\Documents\GitHub\package-panic\swc\SWC_ContainerMenu.swc</path-element>
-      <path-element>C:\Users\Someone\Documents\GitHub\package-panic\swc\SWC_GameCursor.swc</path-element>
-      <path-element>C:\Users\Someone\Documents\GitHub\package-panic\swc\SWC_ContainerGame.swc</path-element>
-      <path-element>C:\Users\Someone\Documents\GitHub\package-panic\swc\Node.swc</path-element>
-      <path-element>C:\Users\Someone\Documents\GitHub\package-panic\swc\Mail.swc</path-element>
+      <path-element>D:\Documents\GitHub\package-panic\swc\SWC_ContainerMenu.swc</path-element>
+      <path-element>D:\Documents\GitHub\package-panic\swc\SWC_GameCursor.swc</path-element>
+      <path-element>D:\Documents\GitHub\package-panic\swc\SWC_ContainerGame.swc</path-element>
+      <path-element>D:\Documents\GitHub\package-panic\swc\Node.swc</path-element>
+      <path-element>D:\Documents\GitHub\package-panic\swc\Mail.swc</path-element>
     </library-path>
   </compiler>
   <file-specs>
-    <path-element>C:\Users\Someone\Documents\GitHub\package-panic\src\packpan\Main.as</path-element>
+    <path-element>D:\Documents\GitHub\package-panic\src\packpan\Main.as</path-element>
   </file-specs>
   <default-background-color>#C0C0C0</default-background-color>
   <default-frame-rate>30</default-frame-rate>

--- a/obj/PackagePanicConfig.xml
+++ b/obj/PackagePanicConfig.xml
@@ -16,7 +16,7 @@
     </define>
     <define append="true">
       <name>CONFIG::timeStamp</name>
-      <value>'2/16/2015'</value>
+      <value>'2/25/2015'</value>
     </define>
     <define append="true">
       <name>CONFIG::air</name>
@@ -32,19 +32,19 @@
     </define>
     <verbose-stacktraces>true</verbose-stacktraces>
     <source-path append="true">
-      <path-element>C:\Users\Someone\Documents\GitHub\package-panic\src</path-element>
+      <path-element>D:\Documents\GitHub\package-panic\src</path-element>
       <path-element>C:\Program Files (x86)\FlashDevelop\Library\AS3\classes</path-element>
     </source-path>
     <library-path append="true">
-      <path-element>C:\Users\Someone\Documents\GitHub\package-panic\swc\SWC_ContainerMenu.swc</path-element>
-      <path-element>C:\Users\Someone\Documents\GitHub\package-panic\swc\SWC_GameCursor.swc</path-element>
-      <path-element>C:\Users\Someone\Documents\GitHub\package-panic\swc\SWC_ContainerGame.swc</path-element>
-      <path-element>C:\Users\Someone\Documents\GitHub\package-panic\swc\Node.swc</path-element>
-      <path-element>C:\Users\Someone\Documents\GitHub\package-panic\swc\Mail.swc</path-element>
+      <path-element>D:\Documents\GitHub\package-panic\swc\SWC_ContainerMenu.swc</path-element>
+      <path-element>D:\Documents\GitHub\package-panic\swc\SWC_GameCursor.swc</path-element>
+      <path-element>D:\Documents\GitHub\package-panic\swc\SWC_ContainerGame.swc</path-element>
+      <path-element>D:\Documents\GitHub\package-panic\swc\Node.swc</path-element>
+      <path-element>D:\Documents\GitHub\package-panic\swc\Mail.swc</path-element>
     </library-path>
   </compiler>
   <file-specs>
-    <path-element>C:\Users\Someone\Documents\GitHub\package-panic\src\packpan\Main.as</path-element>
+    <path-element>D:\Documents\GitHub\package-panic\src\packpan\Main.as</path-element>
   </file-specs>
   <default-background-color>#C0C0C0</default-background-color>
   <default-frame-rate>30</default-frame-rate>

--- a/src/cobaltric/ContainerGame.as
+++ b/src/cobaltric/ContainerGame.as
@@ -46,6 +46,10 @@
 		private var GDN_09:NodeUnknown;
 		private var GDN_10:MailUnknown;
 		private var GDN_11:NodeChute;
+		private var GDN_12:MailGarbage;
+		private var GDN_13:MailContraband;
+		private var GDN_14:NodeIncinerator;
+		
 		
 		// timer
 		public var timerTick:Number = 1000 / 30;		// time to take off per frame
@@ -296,7 +300,9 @@
 				var mailFailure:Boolean = false;		// check if any Mail is in failure state
 				for each (var mail:ABST_Mail in mailArray)
 				{
-					var mailState:int = mail.step();
+					var mailState:int = mail.mailState;
+					if (!mail.destroyed)
+						mailState = mail.step();
 					if (mailState != PP.MAIL_SUCCESS)
 						allSuccess = false;
 					if (mailState == PP.MAIL_FAILURE)

--- a/src/packpan/Levels.as
+++ b/src/packpan/Levels.as
@@ -15,6 +15,8 @@ package packpan
 		private var Level_Test1:Class;
 		[Embed(source="../../json/level_testT.json", mimeType="application/octet-stream")]
 		private var Level_TestT:Class;
+		[Embed(source="../../json/level_testJ.json", mimeType="application/octet-stream")]
+		private var Level_TestJ:Class;
 		[Embed(source="../../json/level_barrier.json", mimeType="application/octet-stream")]
 		private var Level_Barrier:Class;
 		[Embed(source="../../json/level_magnet.json", mimeType="application/octet-stream")]
@@ -58,7 +60,7 @@ package packpan
 			pages[0][3] = JSON.parse(new Level_Tut03());
 			pages[0][4] = JSON.parse(new Level_Swap());
 			pages[0][5] = JSON.parse(new Level_Test1());
-			pages[0][6] = JSON.parse(new Level_TestT())
+			pages[0][6] = JSON.parse(new Level_TestJ())
 			pages[0][7] = JSON.parse(new Level_Barrier());
 			pages[0][8] = JSON.parse(new Level_MagnetEasy());
 			pages[0][9] = JSON.parse(new Level_Magnet());

--- a/src/packpan/iface/IDestroyable.as
+++ b/src/packpan/iface/IDestroyable.as
@@ -1,0 +1,29 @@
+package packpan.iface 
+{
+	
+	/**
+	 * ...
+	 * @author James Liu
+	 */
+	public interface IDestroyable 
+	{
+		/**
+		 * Is this object able to be destroyed by the given destructor?
+		 * @param	Object destructor
+		 * @return destroyed or not
+		 */
+		function DestroyedBy(destructor:Object) : Boolean;
+		
+		/**
+		 * Destroy this object
+		 */
+		function Destroy() : void;
+		
+		/**
+		 * Should this object be destroyed to win?
+		 * @return
+		 */
+		function ShouldDestroy() : Boolean;
+	}
+	
+}

--- a/src/packpan/iface/IProcessable.as
+++ b/src/packpan/iface/IProcessable.as
@@ -1,0 +1,31 @@
+package packpan.iface 
+{
+	
+	/**
+	 * ...
+	 * @author James Liu
+	 */
+	public interface IProcessable 
+	{
+		/**
+		 * Is this object able to be processed by the given processor?
+		 * @param	Object processor
+		 * @return destroyed or not
+		 */
+		function ProcessedBy(processor : Object) : Boolean;
+		
+		
+		/**
+		 * Process this object
+		 * @param	Object processor
+		 */
+		function Process(processor : Object) : void;
+		
+		/**
+		 * Should this object be processed to win?
+		 * @return
+		 */
+		function ShouldProcess() : Boolean;
+	}
+	
+}

--- a/src/packpan/mails/ABST_Mail.as
+++ b/src/packpan/mails/ABST_Mail.as
@@ -3,9 +3,12 @@ package packpan.mails
 	import cobaltric.ContainerGame;
 	import flash.display.Bitmap;
 	import flash.display.MovieClip;
+	import flash.errors.IllegalOperationError;
 	import flash.geom.Point;
 	import flash.geom.ColorTransform;
 	import packpan.ABST_GameObject;
+	import packpan.iface.IDestroyable;
+	import packpan.iface.IProcessable;
 	import packpan.PP;
 	import packpan.PhysicalEntity;
 	import packpan.PhysicsUtils;
@@ -13,10 +16,11 @@ package packpan.mails
 	 * An abstract Mail object, extended to become items that are manipulated by nodes.
 	 * @author Alexander Huynh
 	 */
-	public class ABST_Mail extends ABST_GameObject
+	public class ABST_Mail extends ABST_GameObject implements IDestroyable, IProcessable
 	{		
 		public var state:PhysicalEntity;			// the physical state of the mail
 		public var mailState:int = PP.MAIL_IDLE;	// is this mail in a idle, success, or failure state
+		public var destroyed:Boolean = false;
 		
 		/**
 		 * Should only be called through super(), never instantiated.
@@ -47,7 +51,7 @@ package packpan.mails
 		public function step():int
 		{
 			// -- OVERRIDE THIS FUNCTION TO PROVIDE CUSTOM FUNCTIONALITY
-						
+			
 			position = findGridSquare();		// find the current grid coordinates
 			
 			if (position)						// if we are in bounds
@@ -67,6 +71,46 @@ package packpan.mails
 			mc_object.y = mc_pos.y;
 
 			return mailState;
+		}
+		
+		/* INTERFACE packpan.iface.IDestroyable */
+		
+		public function DestroyedBy(destructor : Object):Boolean 
+		{
+			return true;
+		}
+		
+		public final function Destroy():void 
+		{
+			mc_object.visible = false;
+			if (ShouldDestroy()) {
+				mailState = PP.MAIL_SUCCESS;
+			} else {
+				mailState = PP.MAIL_FAILURE;
+			}
+			destroyed = true;
+		}
+		
+		public function ShouldDestroy():Boolean 
+		{
+			return false;
+		}
+		
+		/* INTERFACE packpan.iface.IProcessable */
+		
+		public function ProcessedBy(processor : Object):Boolean 
+		{
+			return false;
+		}
+		
+		public function Process(processor : Object):void 
+		{
+			//Doesn't need processing, thus won't use it
+		}
+		
+		public function ShouldProcess():Boolean 
+		{
+			return false;
 		}
 		
 		/**

--- a/src/packpan/mails/MailContraband.as
+++ b/src/packpan/mails/MailContraband.as
@@ -1,0 +1,29 @@
+package packpan.mails 
+{
+	import cobaltric.ContainerGame;
+	/**
+	 * ...
+	 * @author James LIu
+	 */
+	public class MailContraband extends ABST_Mail
+	{
+		[Embed(source="../../../img/packageNormal.png")]	// embed code; change this path to change the image
+		private var CustomBitmap:Class	// must be directly after the embed code
+		public var is_contraband:Boolean = false;
+		
+		public function MailContraband(_cg:ContainerGame, _json:Object)
+		{
+			super(_cg, _json, new CustomBitmap());
+			if (json["is_contraband"] != null)
+				is_contraband = json["is_contraband"];
+			else
+				is_contraband = getRand(0, 1) > 0.5;
+		}
+		
+		override public function ShouldDestroy():Boolean 
+		{
+			return is_contraband;
+		}
+	}
+
+}

--- a/src/packpan/mails/MailGarbage.as
+++ b/src/packpan/mails/MailGarbage.as
@@ -1,0 +1,24 @@
+package packpan.mails 
+{
+	import cobaltric.ContainerGame;
+	import packpan.iface.IDestroyable;
+	/**
+	 * ...
+	 * @author James LIu
+	 */
+	public class MailGarbage extends ABST_Mail
+	{
+		[Embed(source="../../../img/packageNormal.png")]	// embed code; change this path to change the image
+		private var CustomBitmap:Class	// must be directly after the embed code
+		
+		public function MailGarbage(_cg:ContainerGame, _json:Object)
+		{
+			super(_cg, _json, new CustomBitmap());
+		}
+		
+		override public function ShouldDestroy():Boolean 
+		{
+			return true;
+		}
+	}
+}

--- a/src/packpan/mails/MailNormal.as
+++ b/src/packpan/mails/MailNormal.as
@@ -3,6 +3,8 @@ package packpan.mails
 	import cobaltric.ContainerGame;
 	import flash.geom.ColorTransform;
 	import packpan.iface.IColorable;
+	import packpan.iface.IDestroyable;
+	import packpan.iface.IProcessable;
 	import packpan.PP;
 	
 	/**

--- a/src/packpan/nodes/ABST_NodeProcessor.as
+++ b/src/packpan/nodes/ABST_NodeProcessor.as
@@ -1,0 +1,36 @@
+package packpan.nodes 
+{
+	import cobaltric.ContainerGame;
+	import flash.display.Bitmap;
+	import packpan.mails.ABST_Mail;
+	/**
+	 * ...
+	 * @author James LIu
+	 */
+	public class ABST_NodeProcessor extends ABST_Node
+	{
+		public function ABST_NodeProcessor(_cg:ContainerGame, _json:Object, _bitmap:Bitmap = null)
+		{
+			super(_cg, _json, _bitmap);
+		}
+		
+		override public function affectMail(mail:ABST_Mail):void 
+		{
+			if (mail.ProcessedBy(this))
+				ProcessMail(mail);
+			if (mail.DestroyedBy(this))
+				DestroyMail(mail);
+		}
+		
+		public function DestroyMail(mail : ABST_Mail) : void
+		{
+			mail.Destroy();
+		}
+		
+		public function ProcessMail(mail : ABST_Mail) : void
+		{
+			mail.Process(this);
+		}
+	}
+
+}

--- a/src/packpan/nodes/NodeBin.as
+++ b/src/packpan/nodes/NodeBin.as
@@ -66,7 +66,8 @@ package packpan.nodes
 				occupied = true;
 				
 				// fail if mail and bin are colored and colors don't match.
-				if (mail is IColorable && !isSameColor(IColorable(mail).getColor()))
+				// also fail if the mail should have been destroyed
+				if (mail.ShouldDestroy() || (mail is IColorable && !isSameColor(IColorable(mail).getColor())))
 				{
 					mail.mailState = PP.MAIL_FAILURE;
 					return;

--- a/src/packpan/nodes/NodeIncinerator.as
+++ b/src/packpan/nodes/NodeIncinerator.as
@@ -1,0 +1,25 @@
+package packpan.nodes 
+{
+	import cobaltric.ContainerGame;
+	import packpan.mails.ABST_Mail;
+	/**
+	 * ...
+	 * @author James LIu
+	 */
+	public class NodeIncinerator extends ABST_NodeProcessor
+	{
+		[Embed(source="../../../img/binNormal.png")]	// embed code; change this path to change the image
+		private var CustomBitmap:Class;					// must be directly below the embed code
+		
+		public function NodeIncinerator(_cg:ContainerGame, _json:Object)
+		{
+			super(_cg, _json, new CustomBitmap());
+		}
+		
+		override public function affectMail(mail:ABST_Mail):void 
+		{
+			DestroyMail(mail);
+		}
+	}
+
+}


### PR DESCRIPTION
Added the following:
Destroyable Mail - Mail can now be destroyed. By default, destroying mail leads to failure.
                    Use ShouldDestroy to redefine whether destroying the mail leads to a win or a fail.
                                       Destroyed mail does not get stepped by the game.
Processable Mail - Mail can now be processed to change the state of the mail.
                    By default, processing does nothing to mail.
                    Use ShouldProcess to redefine whether processing is requried to succeed.

MailGarbage - Mail that should be destroyed 100% of the time.
MailContraband - Mail that should be checked.
                 Set is_contraband to true if needs to be destroyed.
                 Set to false if can go in a bin.
                 The lack of a is_contraband in the JSON will randomly choose one or the other.
NodeIncinerator - Destroys all mail that enters it.

None of them have separate graphics, but all have been tested.
